### PR TITLE
Fix undeclared variable error

### DIFF
--- a/apps/build_all.sh
+++ b/apps/build_all.sh
@@ -45,7 +45,8 @@ for makefile in $(find . | grep '/Makefile$'); do
 	popd > /dev/null
 done
 
-if [ ${#failures[@]} -gt 0 ]; then
+# https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
+if [ ${failures[@]+"${failures[@]}"} ]; then
 	echo ""
 	echo "${bold}${red}Build Failures:${normal}"
 	for fail in ${failures[@]}; do


### PR DESCRIPTION
Apparently the way one checks the length of a variable has gotten
more complicated in newer bashes, le sigh

--------

More generally, this repo split seems to have worked correctly / right for me (this issue existed in both repos)