### PR TITLE
U260 cleanups

### DIFF
--- a/apps/AppMakefile.mk
+++ b/apps/AppMakefile.mk
@@ -80,8 +80,6 @@ include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk
 # Turn off some of the less critical warnings while we're developing heavily
 override CPPFLAGS += -Wno-unused-macros
 
-override CFLAGS += -Wno-pointer-sign
-
 override CXXFLAGS += -Wno-suggest-override
 override CXXFLAGS += -Wno-suggest-final-methods
 override CXXFLAGS += -Wno-suggest-final-types

--- a/apps/libsignpost/at_command.c
+++ b/apps/libsignpost/at_command.c
@@ -35,15 +35,16 @@ static int check_custom_buffer(uint8_t* buf, int len, const char* rstring) {
 }
 
 int at_send(int console_num, const char* cmd) {
-    console_write(console_num, (uint8_t*) cmd, strlen(cmd));
-    return AT_SUCCESS;
+    int ret = console_write(console_num, (uint8_t*) cmd, strlen(cmd));
+    if(ret < 0) return AT_ERROR;
+    else return ret;
 }
 
 int at_send_buf(int console_num, uint8_t* buf, size_t len) {
-    console_write(console_num, buf, len);
-    return AT_SUCCESS;
+    int ret = console_write(console_num, buf, len);
+    if(ret < 0) return AT_ERROR;
+    else return ret;
 }
-
 
 int at_wait_for_response(int console_num, uint8_t max_tries) {
     static uint8_t buf[200];
@@ -61,6 +62,8 @@ int at_get_response(int console_num, uint8_t max_tries, uint8_t* buf, size_t max
     for(uint8_t i = 0; i < max_tries; i++) {
 
         int len = console_read(console_num, buf+tlen, max_len-tlen);
+        if(len < 0) return AT_ERROR;
+
         tlen += len;
         int check = check_buffer(buf, tlen);
 
@@ -80,7 +83,8 @@ int at_get_custom_response(int console_num, uint8_t max_tries, uint8_t* buf, siz
     for(uint8_t i = 0; i < max_tries; i++) {
 
         int len = console_read(console_num, buf+tlen, max_len-tlen);
-        printf("Got len: %d\n", len);
+        if(len < 0) return AT_ERROR;
+
         tlen += len;
         int check = check_custom_buffer(buf, tlen, rstring);
 

--- a/apps/libsignpost/at_command.c
+++ b/apps/libsignpost/at_command.c
@@ -8,13 +8,13 @@
 static int check_buffer(uint8_t* buf, int len) {
     //did it end in OK or ERROR?
     if(len >= 4) {
-        if(!strncmp(buf+len-4,"OK\r\n",4)) {
+        if(!strncmp((char*)buf+len-4,"OK\r\n",4)) {
             return AT_SUCCESS;
         }
     }
 
     if(len >= 7) {
-        if(!strncmp(buf+len-7,"ERROR\r\n",7)) {
+        if(!strncmp((char*)buf+len-7,"ERROR\r\n",7)) {
             return AT_ERROR;
         }
     }
@@ -26,7 +26,7 @@ static int check_custom_buffer(uint8_t* buf, int len, const char* rstring) {
 
     int rlen = strlen(rstring);
     if(len >= rlen) {
-        if(!strncmp(buf+len-rlen,rstring,rlen)) {
+        if(!strncmp((char*)buf+len-rlen,rstring,rlen)) {
             return AT_SUCCESS;
         }
     }

--- a/apps/libsignpost/at_command.h
+++ b/apps/libsignpost/at_command.h
@@ -6,10 +6,21 @@
 #define AT_ERROR -1
 #define AT_NO_RESPONSE -2
 
+__attribute__ ((warn_unused_result))
 int at_send(int console_num, const char* cmd);
+
+__attribute__ ((warn_unused_result))
 int at_send_buf(int console_num, uint8_t* buf, size_t len);
 
+
+__attribute__ ((warn_unused_result))
 int at_wait_for_response(int console_num, uint8_t max_tries);
+
+__attribute__ ((warn_unused_result))
 int at_wait_for_custom_response(int console_num, uint8_t max_tries, const char* rstring);
+
+__attribute__ ((warn_unused_result))
 int at_get_response(int console_num, uint8_t max_tries, uint8_t* buf, size_t max_len);
+
+__attribute__ ((warn_unused_result))
 int at_get_custom_response(int console_num, uint8_t max_tries, uint8_t* buf, size_t max_len, const char* rstring);

--- a/apps/libsignpost/multi_console.c
+++ b/apps/libsignpost/multi_console.c
@@ -42,6 +42,7 @@ int console_read_async(int console_num, uint8_t* buf, size_t max_len, subscribe_
     if(ret < 0) return ret;
     ret = subscribe(console_num, 2, cb, NULL);
     if(ret < 0) return ret;
+    else return 0;
 }
 
 int console_write(int console_num, uint8_t* buf, size_t count) {
@@ -68,4 +69,5 @@ int console_write_async(int console_num, uint8_t* buf, size_t count, subscribe_c
     if(ret < 0) return ret;
     ret = subscribe(console_num, 1, cb, NULL);
     if(ret < 0) return ret;
+    else return count;
 }

--- a/apps/libsignpost/multi_console.c
+++ b/apps/libsignpost/multi_console.c
@@ -23,38 +23,49 @@ static void console_callback (
    cp->len = len;
 }
 
-size_t console_read(int console_num, uint8_t* buf, size_t max_len) {
-    allow(console_num, 0, (void*)buf, max_len);
+int console_read(int console_num, uint8_t* buf, size_t max_len) {
+    int ret = allow(console_num, 0, (void*)buf, max_len);
+    if(ret < 0) return ret;
+
     console_callback_struct c;
     c.fired = false;
-    subscribe(console_num, 2, console_callback, &c);
+    ret = subscribe(console_num, 2, console_callback, &c);
+    if(ret < 0) return ret;
 
     yield_for(&c.fired);
 
     return c.len;
 }
 
-void   console_read_async(int console_num, uint8_t* buf, size_t max_len, subscribe_cb cb) {
-    allow(console_num, 0, (void*)buf, max_len);
-    subscribe(console_num, 2, cb, NULL);
+int console_read_async(int console_num, uint8_t* buf, size_t max_len, subscribe_cb cb) {
+    int ret = allow(console_num, 0, (void*)buf, max_len);
+    if(ret < 0) return ret;
+    ret = subscribe(console_num, 2, cb, NULL);
+    if(ret < 0) return ret;
 }
 
-size_t console_write(int console_num, uint8_t* buf, size_t count) {
+int console_write(int console_num, uint8_t* buf, size_t count) {
 
     uint8_t* cbuf = (uint8_t*)malloc(count * sizeof(uint8_t));
     memcpy(cbuf, buf, count);
 
-    allow(console_num, 1, (void*)cbuf, count);
+    int ret = allow(console_num, 1, (void*)cbuf, count);
+    if(ret < 0) return ret;
+
     console_callback_struct c;
     c.fired = false;
-    subscribe(console_num, 1, console_callback, &c);
+
+    ret = subscribe(console_num, 1, console_callback, &c);
+    if(ret < 0) return ret;
 
     yield_for(&c.fired);
 
     return c.len;
 }
 
-void console_write_async(int console_num, uint8_t* buf, size_t count, subscribe_cb cb) {
-    allow(console_num, 1, (void*)buf, count);
-    subscribe(console_num, 1, cb, NULL);
+int console_write_async(int console_num, uint8_t* buf, size_t count, subscribe_cb cb) {
+    int ret = allow(console_num, 1, (void*)buf, count);
+    if(ret < 0) return ret;
+    ret = subscribe(console_num, 1, cb, NULL);
+    if(ret < 0) return ret;
 }

--- a/apps/libsignpost/multi_console.h
+++ b/apps/libsignpost/multi_console.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <tock.h>
 
-size_t console_read(int console_num, uint8_t* buf, size_t max_len);
-void   console_read_async(int console_num, uint8_t* buf, size_t max_len, subscribe_cb cb);
-size_t console_write(int console_num, uint8_t* buf, size_t count);
-void   console_write_async(int console_num, uint8_t* buf, size_t count, subscribe_cb cb);
+int console_read(int console_num, uint8_t* buf, size_t max_len);
+int console_read_async(int console_num, uint8_t* buf, size_t max_len, subscribe_cb cb);
+int console_write(int console_num, uint8_t* buf, size_t count);
+int console_write_async(int console_num, uint8_t* buf, size_t count, subscribe_cb cb);

--- a/apps/libsignpost/sara_u260.c
+++ b/apps/libsignpost/sara_u260.c
@@ -125,7 +125,11 @@ static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) 
 
     char c[15];
     int clen = snprintf(c,15,"%d",len);
-    ret = at_send_buf(SARA_CONSOLE, c, clen);
+    if(clen <= 0) {
+        return SARA_U260_ERROR; 
+    }
+
+    ret = at_send(SARA_CONSOLE, c);
     if (ret < 0) return SARA_U260_ERROR;
 
     ret = at_send(SARA_CONSOLE, "\r");
@@ -226,7 +230,7 @@ int sara_u260_get_post_partial_response(uint8_t* buf, size_t offset, size_t max_
     
     char c[60];
     snprintf(c,60,"%d,%d\r",offset,max_len);
-    ret = at_send_buf(SARA_CONSOLE,c,strlen(c));
+    ret = at_send(SARA_CONSOLE,c);
     if (ret < 0) return SARA_U260_ERROR;
 
     //should return data plus some framing characters, so take the

--- a/apps/libsignpost/sara_u260.c
+++ b/apps/libsignpost/sara_u260.c
@@ -95,7 +95,7 @@ static int sara_u260_setup_packet_switch(void) {
 static int sara_u260_del_file(const char* fname) {
     int ret;
 
-    ret = at_send(SARA_CONSOLE, "AT+DELFILE=\"");
+    ret = at_send(SARA_CONSOLE, "AT+UDELFILE=\"");
     if (ret < 0) return SARA_U260_ERROR;
 
     ret = at_send(SARA_CONSOLE, fname);
@@ -114,7 +114,7 @@ static int sara_u260_del_file(const char* fname) {
 
 static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) {
     
-    int ret = at_send(SARA_CONSOLE, "AT+DWNFILE=\"");
+    int ret = at_send(SARA_CONSOLE, "AT+UDWNFILE=\"");
     if (ret < 0) return SARA_U260_ERROR;
 
     ret = at_send(SARA_CONSOLE, fname);
@@ -124,7 +124,7 @@ static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) 
     if (ret < 0) return SARA_U260_ERROR;
 
     char c[15];
-    int clen = snprintf(c,15,"%zu",len);
+    int clen = snprintf(c,15,"%lu",(uint32_t)len);
     if(clen <= 0) {
         return SARA_U260_ERROR; 
     }
@@ -167,9 +167,10 @@ int sara_u260_basic_http_post(const char* url, const char* path, uint8_t* buf, s
 
     //delete the file
     ret = sara_u260_del_file("postdata.bin");
-    if(ret < 0) {
+    //Don't catch this error - the file might not exist
+    /*if(ret < 0) {
         return ret;
-    }
+    }*/
 
     //write the data to a file
     ret = sara_u260_write_to_file("postdata.bin", buf, len);
@@ -229,7 +230,7 @@ int sara_u260_get_post_partial_response(uint8_t* buf, size_t offset, size_t max_
 
     
     char c[60];
-    snprintf(c,60,"%zu,%zu\r",offset,max_len);
+    snprintf(c,60,"%lu,%lu\r",(uint32_t)offset,(uint32_t)max_len);
     ret = at_send(SARA_CONSOLE,c);
     if (ret < 0) return SARA_U260_ERROR;
 

--- a/apps/libsignpost/sara_u260.c
+++ b/apps/libsignpost/sara_u260.c
@@ -113,6 +113,17 @@ static int sara_u260_del_file(const char* fname) {
 }
 
 static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) {
+    
+    const char* begin = "AT+UDWFILE=\""
+    int ret = at_send_buf(SARA_CONSOLE, (const uint8_t*)begin, strlen(begin));
+    if (ret < 0) return SARA_U260_ERROR;
+
+
+    ret = at_send_buf(SARA_CONSOLE, fname, strlen(fname));
+    if (ret < 0) return SARA_U260_ERROR;
+
+    const char* sep = "\"
+    ret = at_send_buf(SARA_CONSOLE, fname, strlen(fname));
 
     int ret = at_send(SARA_CONSOLE, "AT+DWNFILE=\"");
     if (ret < 0) return SARA_U260_ERROR;

--- a/apps/libsignpost/sara_u260.c
+++ b/apps/libsignpost/sara_u260.c
@@ -10,12 +10,15 @@
 #define SARA_CONSOLE 110
 
 int sara_u260_init(void) {
-    at_send(SARA_CONSOLE,"AT\r");
+    int ret = at_send(SARA_CONSOLE,"AT\r");
+    if (ret < 0) return SARA_U260_ERROR;
 
     for(volatile uint32_t i = 0; i < 15000; i++);
 
-    at_send(SARA_CONSOLE,"ATE0\r");
-    int ret = at_wait_for_response(SARA_CONSOLE,3);
+    ret = at_send(SARA_CONSOLE,"ATE0\r");
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_wait_for_response(SARA_CONSOLE,3);
     if(ret >= AT_SUCCESS) {
         return SARA_U260_SUCCESS;
     } else {
@@ -24,8 +27,11 @@ int sara_u260_init(void) {
 }
 
 static int sara_u260_check_connection(void) {
-    at_send(SARA_CONSOLE, "AT+COPS?\r");
+    int ret = at_send(SARA_CONSOLE, "AT+COPS?\r");
+    if (ret < 0) return SARA_U260_ERROR;
 
+    //We just need to check how many bytes it will return
+    //This tells us if the operator field is populated (has service)
     uint8_t buf[50];
     int len = at_get_response(SARA_CONSOLE, 3, buf, 50);
 
@@ -46,21 +52,31 @@ static int sara_u260_setup_packet_switch(void) {
     }
 
     //do we already have a pack switch setup?
-    at_send(SARA_CONSOLE,"AT+UPSND=0,0\r");
+    ret = at_send(SARA_CONSOLE,"AT+UPSND=0,0\r");
+    if (ret < 0) return SARA_U260_ERROR;
+
     ret = at_wait_for_response(SARA_CONSOLE, 3);
     if(ret == AT_ERROR) {
         //no we need to set one up
 
         //set the apn for our network - it can be blank
-        at_send(SARA_CONSOLE, "AT+UPSD=0,1,\"\"\r");
-        at_wait_for_response(SARA_CONSOLE, 3);
+        ret = at_send(SARA_CONSOLE, "AT+UPSD=0,1,\"\"\r");
+        if (ret < 0) return SARA_U260_ERROR;
+
+        ret = at_wait_for_response(SARA_CONSOLE, 3);
+        if (ret < 0) return SARA_U260_ERROR;
 
         //request to connect
-        at_send(SARA_CONSOLE, "AT+UPSDA=0,3\r");
-        at_wait_for_response(SARA_CONSOLE, 3);
+        ret = at_send(SARA_CONSOLE, "AT+UPSDA=0,3\r");
+        if (ret < 0) return SARA_U260_ERROR;
+
+        ret = at_wait_for_response(SARA_CONSOLE, 3);
+        if (ret < 0) return SARA_U260_ERROR;
 
         //did it work
-        at_send(SARA_CONSOLE,"AT+UPSND=0,0\r");
+        ret = at_send(SARA_CONSOLE,"AT+UPSND=0,0\r");
+        if (ret < 0) return SARA_U260_ERROR;
+
         ret = at_wait_for_response(SARA_CONSOLE, 3);
 
         if(ret < 0) {
@@ -79,16 +95,14 @@ static int sara_u260_setup_packet_switch(void) {
 static int sara_u260_del_file(const char* fname) {
     int ret;
 
-    const char* begin = "AT+UDELFILE=\"";
-    ret = at_send_buf(SARA_CONSOLE, (const uint8_t*)begin, strlen(begin));
-    if (ret < 0) return ret;
+    ret = at_send(SARA_CONSOLE, "AT+DELFILE=\"");
+    if (ret < 0) return SARA_U260_ERROR;
 
     ret = at_send_buf(SARA_CONSOLE, fname, strlen(fname));
-    if (ret < 0) return ret;
+    if (ret < 0) return SARA_U260_ERROR;
 
-    const char* end = "\"\r";
-    ret = at_send_buf(SARA_CONSOLE, (const uint8_t*)end, strlen(begin));
-    if (ret < 0) return ret;
+    ret = at_send_buf(SARA_CONSOLE, "\"\r");
+    if (ret < 0) return SARA_U260_ERROR;
 
     ret = at_wait_for_response(SARA_CONSOLE,3);
     if(ret >= 0) {
@@ -100,10 +114,25 @@ static int sara_u260_del_file(const char* fname) {
 
 static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) {
 
-    char* c = (char*)malloc(strlen(fname)*sizeof(char)+17);
-    int clen = sprintf(c, "AT+UDWNFILE=\"%s\",%d\r", fname, len);
-    at_send_buf(SARA_CONSOLE, c, clen);
-    at_wait_for_custom_response(SARA_CONSOLE,3,"\n>");
+    int ret = at_send(SARA_CONSOLE, "AT+DWNFILE=\"");
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_send(SARA_CONSOLE, fname);
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_send(SARA_CONSOLE, "\",");
+    if (ret < 0) return SARA_U260_ERROR;
+
+    char c[15];
+    int clen = snprintf(c,15,"%d",len);
+    ret = at_send_buf(SARA_CONSOLE, c, clen);
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_send(SARA_CONSOLE, "\r");
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_wait_for_custom_response(SARA_CONSOLE,3,"\n>");
+    if (ret < 0) return SARA_U260_ERROR;
 
     //now send the buffer in chunks of 30
     for(size_t i = 0; i < len; i+=30) {
@@ -112,10 +141,6 @@ static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) 
         } else {
             at_send_buf(SARA_CONSOLE, buf+i, len-i);
         }
-    }
-
-    if(c) {
-        free(c);
     }
 
     int ret = at_wait_for_response(SARA_CONSOLE,3);
@@ -147,21 +172,40 @@ int sara_u260_basic_http_post(const char* url, const char* path, uint8_t* buf, s
     }
 
     //setup http profile
-    at_send(SARA_CONSOLE,"AT+UHTTP=0\r");
-    at_wait_for_response(SARA_CONSOLE, 3);
+    ret = at_send(SARA_CONSOLE,"AT+UHTTP=0\r");
+    if (ret < 0) return SARA_U260_ERROR;
 
-    at_send(SARA_CONSOLE,"AT+UHTTP=0,1,\"");
-    at_send(SARA_CONSOLE,url);
-    at_send(SARA_CONSOLE,"\"\r");
-    at_wait_for_response(SARA_CONSOLE, 3);
+    ret = at_wait_for_response(SARA_CONSOLE, 3);
+    if (ret < 0) return SARA_U260_ERROR;
 
-    at_send(SARA_CONSOLE,"AT+UHTTP=0,5,80\r");
-    at_wait_for_response(SARA_CONSOLE, 3);
+    ret = at_send(SARA_CONSOLE,"AT+UHTTP=0,1,\"");
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_send(SARA_CONSOLE,url);
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_send(SARA_CONSOLE,"\"\r");
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_wait_for_response(SARA_CONSOLE, 3);
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_send(SARA_CONSOLE,"AT+UHTTP=0,5,80\r");
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_wait_for_response(SARA_CONSOLE, 3);
+    if (ret < 0) return SARA_U260_ERROR;
 
     //now actually do the post
-    at_send(SARA_CONSOLE,"AT+UHTTPC=0,4,\"");
-    at_send(SARA_CONSOLE,path);
-    at_send(SARA_CONSOLE,"\",\"postresult.txt\",\"postdata.bin\",2\r");
+    ret = at_send(SARA_CONSOLE,"AT+UHTTPC=0,4,\"");
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_send(SARA_CONSOLE,path);
+    if (ret < 0) return SARA_U260_ERROR;
+
+    ret = at_send(SARA_CONSOLE,"\",\"postresult.txt\",\"postdata.bin\",2\r");
+    if (ret < 0) return SARA_U260_ERROR;
+
     ret = at_wait_for_response(SARA_CONSOLE, 3);
 
     return ret;
@@ -172,12 +216,26 @@ int sara_u260_get_post_response(uint8_t* buf, size_t max_len) {
 }
 
 int sara_u260_get_post_partial_response(uint8_t* buf, size_t offset, size_t max_len) {
+    
+    int ret = at_send(SARA_CONSOLE,"AT+URDBLOCK=\"postresult.txt\",");
+    if (ret < 0) return SARA_U260_ERROR;
+
+
+    
     char c[60];
-    sprintf(c, "AT+URDBLOCK=\"postresult.txt\",%d,%d\r",offset,max_len);
-    at_send_buf(SARA_CONSOLE,c,strlen(c));
+    snprintf(c,60,"%d,%d\r",offset,max_len);
+    ret = at_send_buf(SARA_CONSOLE,c,strlen(c));
+    if (ret < 0) return SARA_U260_ERROR;
+
+    //should return data plus some framing characters, so take the
+    //data length being returned and add some room
 
     int len = max_len+100;
     uint8_t* tbuf = (uint8_t*)malloc(max_len*sizeof(uint8_t)+100);
+    if(!tbuf) {
+        return SARA_U260_ERROR;
+    }
+
     int ret = at_get_response(SARA_CONSOLE,3,tbuf,len);
     len = ret;
 

--- a/apps/libsignpost/sara_u260.c
+++ b/apps/libsignpost/sara_u260.c
@@ -76,16 +76,20 @@ static int sara_u260_setup_packet_switch(void) {
 }
 
 static int sara_u260_del_file(const char* fname) {
+    int ret;
 
-    char* c = (char*)malloc(strlen(fname)*sizeof(char)+17);
-    int clen = sprintf(c, "AT+UDELFILE=\"%s\"\r", fname);
-    at_send_buf(SARA_CONSOLE, c, clen);
-    int ret = at_wait_for_response(SARA_CONSOLE,3);
-    
-    if(c) {
-        free(c);
-    }
+    const char* begin = "AT+UDELFILE=\"";
+    ret = at_send_buf(SARA_CONSOLE, (const uint8_t*)begin, strlen(begin));
+    if (ret < 0) return ret;
 
+    ret = at_send_buf(SARA_CONSOLE, fname, strlen(fname));
+    if (ret < 0) return ret;
+
+    const char* end = "\"\r";
+    ret = at_send_buf(SARA_CONSOLE, (const uint8_t*)end, strlen(begin));
+    if (ret < 0) return ret;
+
+    ret = at_wait_for_response(SARA_CONSOLE,3);
     if(ret >= 0) {
         return SARA_U260_SUCCESS;
     } else {

--- a/apps/libsignpost/sara_u260.c
+++ b/apps/libsignpost/sara_u260.c
@@ -124,7 +124,7 @@ static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) 
     if (ret < 0) return SARA_U260_ERROR;
 
     char c[15];
-    int clen = snprintf(c,15,"%d",len);
+    int clen = snprintf(c,15,"%zu",len);
     if(clen <= 0) {
         return SARA_U260_ERROR; 
     }
@@ -229,7 +229,7 @@ int sara_u260_get_post_partial_response(uint8_t* buf, size_t offset, size_t max_
 
     
     char c[60];
-    snprintf(c,60,"%d,%d\r",offset,max_len);
+    snprintf(c,60,"%zu,%zu\r",offset,max_len);
     ret = at_send(SARA_CONSOLE,c);
     if (ret < 0) return SARA_U260_ERROR;
 
@@ -246,9 +246,7 @@ int sara_u260_get_post_partial_response(uint8_t* buf, size_t offset, size_t max_
     len = ret;
 
     if(ret < 0) {
-        if(tbuf) {
-            free(tbuf);
-        }
+        free(tbuf);
 
         return SARA_U260_ERROR;
     }
@@ -271,9 +269,7 @@ int sara_u260_get_post_partial_response(uint8_t* buf, size_t offset, size_t max_
     }
 
     if(c1 == 0 || c2 ==0) {
-        if(tbuf) {
-            free(tbuf);
-        }
+        free(tbuf);
         return SARA_U260_ERROR;
     }
 
@@ -282,18 +278,14 @@ int sara_u260_get_post_partial_response(uint8_t* buf, size_t offset, size_t max_
     int dlen = atoi(dl);
 
     if(dlen >=0 && (size_t)dlen >= max_len) {
-        if(tbuf) {
-            free(tbuf);
-        }
+        free(tbuf);
         return SARA_U260_ERROR;
     }
 
     //now manually memcpy out the data into tbuf (because there could be nulls)
     memcpy(buf,tbuf+(len - 7 - dlen),dlen);
 
-    if(tbuf) {
-        free(tbuf);
-    }
+    free(tbuf);
 
     return dlen;
 }

--- a/apps/libsignpost/sara_u260.c
+++ b/apps/libsignpost/sara_u260.c
@@ -1,10 +1,11 @@
 #include <stdint.h>
-#include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "at_command.h"
 #include "sara_u260.h"
 #include "tock.h"
-#include <stdlib.h>
-#include "at_command.h"
 
 #define SARA_CONSOLE 110
 

--- a/apps/libsignpost/sara_u260.c
+++ b/apps/libsignpost/sara_u260.c
@@ -98,10 +98,10 @@ static int sara_u260_del_file(const char* fname) {
     ret = at_send(SARA_CONSOLE, "AT+DELFILE=\"");
     if (ret < 0) return SARA_U260_ERROR;
 
-    ret = at_send_buf(SARA_CONSOLE, fname, strlen(fname));
+    ret = at_send(SARA_CONSOLE, fname);
     if (ret < 0) return SARA_U260_ERROR;
 
-    ret = at_send_buf(SARA_CONSOLE, "\"\r");
+    ret = at_send(SARA_CONSOLE, "\"\r");
     if (ret < 0) return SARA_U260_ERROR;
 
     ret = at_wait_for_response(SARA_CONSOLE,3);
@@ -114,17 +114,6 @@ static int sara_u260_del_file(const char* fname) {
 
 static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) {
     
-    const char* begin = "AT+UDWFILE=\""
-    int ret = at_send_buf(SARA_CONSOLE, (const uint8_t*)begin, strlen(begin));
-    if (ret < 0) return SARA_U260_ERROR;
-
-
-    ret = at_send_buf(SARA_CONSOLE, fname, strlen(fname));
-    if (ret < 0) return SARA_U260_ERROR;
-
-    const char* sep = "\"
-    ret = at_send_buf(SARA_CONSOLE, fname, strlen(fname));
-
     int ret = at_send(SARA_CONSOLE, "AT+DWNFILE=\"");
     if (ret < 0) return SARA_U260_ERROR;
 
@@ -148,13 +137,15 @@ static int sara_u260_write_to_file(const char* fname, uint8_t* buf, size_t len) 
     //now send the buffer in chunks of 30
     for(size_t i = 0; i < len; i+=30) {
         if(i+30 <= len) {
-            at_send_buf(SARA_CONSOLE, buf+i, 30);
+            ret = at_send_buf(SARA_CONSOLE, buf+i, 30);
+            if (ret < 0) return SARA_U260_ERROR;
         } else {
-            at_send_buf(SARA_CONSOLE, buf+i, len-i);
+            ret = at_send_buf(SARA_CONSOLE, buf+i, len-i);
+            if (ret < 0) return SARA_U260_ERROR;
         }
     }
 
-    int ret = at_wait_for_response(SARA_CONSOLE,3);
+    ret = at_wait_for_response(SARA_CONSOLE,3);
     if(ret >= AT_SUCCESS) {
         return SARA_U260_SUCCESS;
     } else {
@@ -247,7 +238,7 @@ int sara_u260_get_post_partial_response(uint8_t* buf, size_t offset, size_t max_
         return SARA_U260_ERROR;
     }
 
-    int ret = at_get_response(SARA_CONSOLE,3,tbuf,len);
+    ret = at_get_response(SARA_CONSOLE,3,tbuf,len);
     len = ret;
 
     if(ret < 0) {

--- a/apps/libsignpost/xdot.c
+++ b/apps/libsignpost/xdot.c
@@ -30,7 +30,6 @@ int xdot_init(void) {
     ret = at_wait_for_response(LORA_CONSOLE,3);
     if(ret < 0) return XDOT_ERROR;
     else return XDOT_SUCCESS;
-    
 }
 
 int xdot_join_network(uint8_t* AppEUI, uint8_t* AppKey) {
@@ -149,7 +148,7 @@ int xdot_set_txdr(uint8_t dr) {
     }
 
     char cmd[15];
-    snprintf(cmd,15, "AT+TXDR=%d\n", dr);
+    snprintf(cmd,15, "AT+TXDR=%u\n", dr);
     int ret = at_send(LORA_CONSOLE, cmd);
     if(ret < 0) return XDOT_ERROR;
 
@@ -166,7 +165,7 @@ int xdot_set_adr(uint8_t adr) {
     if(ret < 0) return XDOT_ERROR;
 
     char cmd[4];
-    snprintf(cmd,4, "%d\n", adr);
+    snprintf(cmd,4, "%u\n", adr);
 
     ret = at_send(LORA_CONSOLE,cmd);
     if(ret < 0) return XDOT_ERROR;
@@ -184,7 +183,7 @@ int xdot_set_txpwr(uint8_t tx) {
     if(ret < 0) return XDOT_ERROR;
 
     char cmd[4];
-    snprintf(cmd,4, "%d\n", tx);
+    snprintf(cmd,4, "%u\n", tx);
     ret = at_send(LORA_CONSOLE,cmd);
     if(ret < 0) return XDOT_ERROR;
 
@@ -201,7 +200,7 @@ int xdot_set_ack(uint8_t ack) {
     if(ret < 0) return XDOT_ERROR;
 
     char cmd[4];
-    snprintf(cmd,4, "%d\n",ack);
+    snprintf(cmd,4, "%u\n",ack);
     ret = at_send(LORA_CONSOLE,cmd);
     if(ret < 0) return XDOT_ERROR;
 

--- a/apps/libsignpost/xdot.c
+++ b/apps/libsignpost/xdot.c
@@ -24,71 +24,105 @@
 int xdot_init(void) {
     gpio_enable_output(LORA_WAKE_PIN);
 
-    at_send(LORA_CONSOLE, "ATE0\n");
-    return at_wait_for_response(LORA_CONSOLE,3);
+    int ret = at_send(LORA_CONSOLE, "ATE0\n");
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
+    else return XDOT_SUCCESS;
+    
 }
 
 int xdot_join_network(uint8_t* AppEUI, uint8_t* AppKey) {
-    at_send(LORA_CONSOLE, "AT\n");
-    at_wait_for_response(LORA_CONSOLE,3);
+    int ret = at_send(LORA_CONSOLE, "AT\n");
+    if(ret < 0) return XDOT_ERROR;
+    
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
 
-    at_send(LORA_CONSOLE, "AT+NJM=1\n");
-    at_wait_for_response(LORA_CONSOLE,3);
+    ret = at_send(LORA_CONSOLE, "AT+NJM=1\n");
+    if(ret < 0) return XDOT_ERROR;
 
-    static char c[200];
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
 
+
+    ret = at_send(LORA_CONSOLE, "AT+NI=0,");
+    if(ret < 0) return XDOT_ERROR;
+
+    char c[200];
     uint8_t len = 0;
-    strcpy(c, "AT+NI=0,");
-    len = 8;
-    char* cpt = c+8;
+    char* cpt = c;
     for(uint8_t i = 0; i < 8; i++) {
-        sprintf(cpt,"%02X",AppEUI[i]);
+        snprintf(cpt,2,"%02X",AppEUI[i]);
         cpt += 2;
         len += 2;
     }
-    sprintf(cpt, "\n");
-    len += 1;
-    at_send_buf(LORA_CONSOLE,c,len);
-    at_wait_for_response(LORA_CONSOLE,3);
+
+    ret = at_send_buf(LORA_CONSOLE,c,len);
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_send(LORA_CONSOLE,"\n");
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
+
+   
+    ret = at_send(LORA_CONSOLE, "AT+NK=0,");
+    if(ret < 0) return XDOT_ERROR;
 
     len = 0;
-    strcpy(c, "AT+NK=0,");
-    len = 8;
-    cpt = c+8;
+    cpt = c;
     for(uint8_t i = 0; i < 16; i++) {
-        sprintf(cpt,"%02X",AppKey[i]);
+        snprintf(cpt,2,"%02X",AppKey[i]);
         cpt += 2;
         len += 2;
     }
-    sprintf(cpt, "\n");
-    len += 1;
-    at_send_buf(LORA_CONSOLE,c,len);
-    at_wait_for_response(LORA_CONSOLE,3);
 
-    at_send(LORA_CONSOLE,"AT+PN=1\n");
-    at_wait_for_response(LORA_CONSOLE,3);
+    ret = at_send_buf(LORA_CONSOLE,c,len);
+    if(ret < 0) return XDOT_ERROR;
 
-    at_send(LORA_CONSOLE,"AT+FSB=1\n");
-    at_wait_for_response(LORA_CONSOLE,3);
+    ret = at_send(LORA_CONSOLE,"\n");
+    if(ret < 0) return XDOT_ERROR;
 
-    at_send(LORA_CONSOLE,"AT&W\n");
-    at_wait_for_response(LORA_CONSOLE,3);
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
 
-    xdot_reset();
+    ret = at_send(LORA_CONSOLE,"AT+PN=1\n");
+    if(ret < 0) return XDOT_ERROR;
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
 
-    at_send(LORA_CONSOLE,"AT+JOIN\n");
-    at_wait_for_response(LORA_CONSOLE,3);
+    ret = at_send(LORA_CONSOLE,"AT+FSB=1\n");
+    if(ret < 0) return XDOT_ERROR;
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_send(LORA_CONSOLE,"AT&W\n");
+    if(ret < 0) return XDOT_ERROR;
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = xdot_reset();
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_send(LORA_CONSOLE,"AT+JOIN\n");
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
 
     return XDOT_SUCCESS;
 }
 
 int xdot_get_txdr(void) {
-    char cmd[15];
-    sprintf(cmd, "AT+TXDR?\n");
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
+    
+    int ret = at_send(LORA_CONSOLE,"AT+TXDR?\n");
+    if(ret < 0) return XDOT_ERROR;
 
     uint8_t buf[200];
-    int ret = at_get_response(LORA_CONSOLE, 3, buf, 200);
+    ret = at_get_response(LORA_CONSOLE, 3, buf, 200);
 
     if(ret <= 0) {
         return ret;
@@ -115,8 +149,10 @@ int xdot_set_txdr(uint8_t dr) {
     }
 
     char cmd[15];
-    sprintf(cmd, "AT+TXDR=%d\n", dr);
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
+    snprintf(cmd,15, "AT+TXDR=%d\n", dr);
+    int ret = at_send_buf(LORA_CONSOLE, cmd, strlen(cmd));
+    if(ret < 0) return XDOT_ERROR;
+
     return at_wait_for_response(LORA_CONSOLE,3);
 }
 
@@ -126,9 +162,15 @@ int xdot_set_adr(uint8_t adr) {
         return XDOT_INVALID_PARAM;
     }
 
-    char cmd[15];
-    sprintf(cmd, "AT+ADR=%d\n", adr);
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
+    int ret = at_send(LORA_CONSOLE,"AT+ADR=");
+    if(ret < 0) return XDOT_ERROR;
+
+    char cmd[4];
+    snprintf(cmd,4, "%d\n", adr);
+
+    ret = at_send_buf(LORA_CONSOLE,cmd,strlen(cmd));
+    if(ret < 0) return XDOT_ERROR;
+    
     return at_wait_for_response(LORA_CONSOLE,3);
 }
 
@@ -138,9 +180,14 @@ int xdot_set_txpwr(uint8_t tx) {
         return XDOT_INVALID_PARAM;
     }
 
-    char cmd[15];
-    sprintf(cmd, "AT+TXP=%d\n", tx);
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
+    int ret = at_send(LORA_CONSOLE,"AT+TXP=");
+    if(ret < 0) return XDOT_ERROR;
+
+    char cmd[4];
+    snprintf(cmd,4, "%d\n", tx);
+    ret = at_send_buf(LORA_CONSOLE,cmd,strlen(cmd));
+    if(ret < 0) return XDOT_ERROR;
+
     return at_wait_for_response(LORA_CONSOLE,3);
 }
 
@@ -150,49 +197,64 @@ int xdot_set_ack(uint8_t ack) {
         return XDOT_INVALID_PARAM;
     }
 
-    char cmd[15];
-    sprintf(cmd, "AT+ACK=%d\n",ack);
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
+    int ret = at_send(LORA_CONSOLE,"AT+ACK=");
+    if(ret < 0) return XDOT_ERROR;
+
+    char cmd[4];
+    snprintf(cmd,4, "%d\n",ack);
+    ret = at_send_buf(LORA_CONSOLE,cmd,strlen(cmd));
+    if(ret < 0) return XDOT_ERROR;
+
     return at_wait_for_response(LORA_CONSOLE,3);
 }
 
 int xdot_save_settings(void) {
-    char cmd[15];
-    sprintf(cmd, "AT&W\n");
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
+    int ret = at_send(LORA_CONSOLE, "AT&W\n");
+    if(ret < 0) return XDOT_ERROR;
+
     return at_wait_for_response(LORA_CONSOLE,3);
 }
 
 int xdot_reset(void) {
-    char cmd[15];
-    sprintf(cmd, "ATZ\n");
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
-    at_wait_for_response(LORA_CONSOLE,3);
+    
+    int ret = at_send(LORA_CONSOLE, "ATZ\n");
+    if(ret < 0) return XDOT_ERROR;
+    
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
 
     for(volatile uint32_t i = 0; i < 1500000; i++);
 
-    sprintf(cmd, "AT\n");
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
-    return at_wait_for_response(LORA_CONSOLE,3);
+    ret = at_send(LORA_CONSOLE, "AT\n");
+    if(ret < 0) return XDOT_ERROR;
 
+    return at_wait_for_response(LORA_CONSOLE,3);
 }
 
 int xdot_send(uint8_t* buf, uint8_t len) {
-    const char* cmd = "AT+send=";
-    console_write(LORA_CONSOLE, (uint8_t*)cmd , strlen(cmd));
-    console_write(LORA_CONSOLE, buf, len);
-    console_write(LORA_CONSOLE, (uint8_t*)"\n", 1);
+    
+    int ret = at_send(LORA_CONSOLE, "AT+send=");
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_send_buf(LORA_CONSOLE,buf,len);
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_send(LORA_CONSOLE, "\n");
+    if(ret < 0) return XDOT_ERROR;
+    
     return at_wait_for_response(LORA_CONSOLE,3);
 }
 
 int xdot_sleep(void) {
-    char cmd[15];
-    sprintf(cmd, "AT+WM=1\n");
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
-    at_wait_for_response(LORA_CONSOLE,3);
+    int ret = at_send(LORA_CONSOLE, "AT+WM=1\n");
+    if(ret < 0) return XDOT_ERROR;
 
-    sprintf(cmd, "AT+sleep\n");
-    console_write(LORA_CONSOLE, cmd, strlen(cmd));
+    ret = at_wait_for_response(LORA_CONSOLE,3);
+    if(ret < 0) return XDOT_ERROR;
+
+    ret = at_send(LORA_CONSOLE, "AT+sleep\n");
+    if(ret < 0) return XDOT_ERROR;
+
     return at_wait_for_response(LORA_CONSOLE,3);
 }
 

--- a/apps/libsignpost/xdot.c
+++ b/apps/libsignpost/xdot.c
@@ -59,7 +59,7 @@ int xdot_join_network(uint8_t* AppEUI, uint8_t* AppKey) {
         len += 2;
     }
 
-    ret = at_send_buf(LORA_CONSOLE,c,len);
+    ret = at_send_buf(LORA_CONSOLE,(uint8_t*)c,len);
     if(ret < 0) return XDOT_ERROR;
 
     ret = at_send(LORA_CONSOLE,"\n");
@@ -80,7 +80,7 @@ int xdot_join_network(uint8_t* AppEUI, uint8_t* AppKey) {
         len += 2;
     }
 
-    ret = at_send_buf(LORA_CONSOLE,c,len);
+    ret = at_send_buf(LORA_CONSOLE,(uint8_t*)c,len);
     if(ret < 0) return XDOT_ERROR;
 
     ret = at_send(LORA_CONSOLE,"\n");
@@ -150,7 +150,7 @@ int xdot_set_txdr(uint8_t dr) {
 
     char cmd[15];
     snprintf(cmd,15, "AT+TXDR=%d\n", dr);
-    int ret = at_send_buf(LORA_CONSOLE, cmd, strlen(cmd));
+    int ret = at_send(LORA_CONSOLE, cmd);
     if(ret < 0) return XDOT_ERROR;
 
     return at_wait_for_response(LORA_CONSOLE,3);
@@ -168,7 +168,7 @@ int xdot_set_adr(uint8_t adr) {
     char cmd[4];
     snprintf(cmd,4, "%d\n", adr);
 
-    ret = at_send_buf(LORA_CONSOLE,cmd,strlen(cmd));
+    ret = at_send(LORA_CONSOLE,cmd);
     if(ret < 0) return XDOT_ERROR;
     
     return at_wait_for_response(LORA_CONSOLE,3);
@@ -185,7 +185,7 @@ int xdot_set_txpwr(uint8_t tx) {
 
     char cmd[4];
     snprintf(cmd,4, "%d\n", tx);
-    ret = at_send_buf(LORA_CONSOLE,cmd,strlen(cmd));
+    ret = at_send(LORA_CONSOLE,cmd);
     if(ret < 0) return XDOT_ERROR;
 
     return at_wait_for_response(LORA_CONSOLE,3);
@@ -202,7 +202,7 @@ int xdot_set_ack(uint8_t ack) {
 
     char cmd[4];
     snprintf(cmd,4, "%d\n",ack);
-    ret = at_send_buf(LORA_CONSOLE,cmd,strlen(cmd));
+    ret = at_send(LORA_CONSOLE,cmd);
     if(ret < 0) return XDOT_ERROR;
 
     return at_wait_for_response(LORA_CONSOLE,3);

--- a/apps/libsignpost/xdot.c
+++ b/apps/libsignpost/xdot.c
@@ -53,7 +53,7 @@ int xdot_join_network(uint8_t* AppEUI, uint8_t* AppKey) {
     uint8_t len = 0;
     char* cpt = c;
     for(uint8_t i = 0; i < 8; i++) {
-        snprintf(cpt,2,"%02X",AppEUI[i]);
+        snprintf(cpt,3,"%02X",AppEUI[i]);
         cpt += 2;
         len += 2;
     }
@@ -74,7 +74,7 @@ int xdot_join_network(uint8_t* AppEUI, uint8_t* AppKey) {
     len = 0;
     cpt = c;
     for(uint8_t i = 0; i < 16; i++) {
-        snprintf(cpt,2,"%02X",AppKey[i]);
+        snprintf(cpt,3,"%02X",AppKey[i]);
         cpt += 2;
         len += 2;
     }

--- a/apps/radio_module/lora_test/main.c
+++ b/apps/radio_module/lora_test/main.c
@@ -18,15 +18,28 @@ int main (void) {
     uint8_t AppEUI[8] = {0xc0, 0x98, 0xe5, 0xc0, 0x00, 0x00, 0x00, 0x00};
     uint8_t AppKey[16] = {0};
     AppKey[15] = 0x01;
-    xdot_init();
 
-    xdot_join_network(AppEUI, AppKey);
+    printf("Initializing...\n");
+    xdot_wake();
+    int ret = xdot_init();
+    if(ret < 0) {
+        printf("Error Initializing\n");
+    }
+
+    printf("Joining network...\n");
+    ret = xdot_join_network(AppEUI, AppKey);
+    if(ret < 0) {
+        printf("Error joining the network\n");
+    }
+
     xdot_set_txdr(4);
     xdot_set_ack(1);
     xdot_set_txpwr(20);
 
     while(1) {
         xdot_wake();
+
+        printf("Sending data\n\n");
         xdot_send((uint8_t*)"Hi From Lab11",13);
         xdot_sleep();
         delay_ms(1000);

--- a/kernel/signpost_drivers/src/xdot.rs
+++ b/kernel/signpost_drivers/src/xdot.rs
@@ -197,7 +197,7 @@ impl<'a, U: UARTAdvanced> Driver for Console<'a, U> {
                                 receive_len = buffer.len();
                             }*/
                             //XXX: this could receive more than the app buffer...
-                            self.uart.receive_automatic(buffer, 10);
+                            self.uart.receive_automatic(buffer, 250);
                         });
 
                         app_buf


### PR DESCRIPTION
This is the start of cleanups for the U260 library. It gives an example of a no-malloc/no-sprintf approach that emits no warnings.

It also adds compiler annotations to warn when return values aren't checked (lots of these are missing)