### PR TITLE
max17205: consistent current signedness

### DIFF
--- a/apps/libsignpost/max17205.c
+++ b/apps/libsignpost/max17205.c
@@ -78,7 +78,7 @@ int max17205_read_soc_sync(uint16_t* percent, uint16_t* soc_mah, uint16_t* soc_m
     return 0;
 }
 
-int max17205_read_voltage_current_sync(uint16_t* voltage, uint16_t* current) {
+int max17205_read_voltage_current_sync(uint16_t* voltage, int16_t* current) {
     int err;
     result.fired = false;
 

--- a/apps/libsignpost/max17205.h
+++ b/apps/libsignpost/max17205.h
@@ -47,7 +47,7 @@ int max17205_read_coulomb (void);
 //
 int max17205_read_status_sync(uint16_t* state);
 int max17205_read_soc_sync(uint16_t* percent, uint16_t* soc_mah, uint16_t* soc_mah_full);
-int max17205_read_voltage_current_sync(uint16_t* voltage, uint16_t* current);
+int max17205_read_voltage_current_sync(uint16_t* voltage, int16_t* current);
 int max17205_read_coulomb_sync (uint16_t* coulomb);
 
 float max17205_get_voltage_mV(int vcount);


### PR DESCRIPTION
The stuff around this seemed assume current is signed (which makes
sense to me):

    int signpost_energy_get_battery_current_ua (void) {
        uint16_t voltage;
        int16_t current;
        max17205_read_voltage_current_sync(&voltage,&current);
        float c = max17205_get_current_uA(current);