### PR TITLE
parses failures with special characters

### DIFF
--- a/apps/build_all.sh
+++ b/apps/build_all.sh
@@ -46,7 +46,7 @@ for makefile in $(find . | grep '/Makefile$'); do
 done
 
 # https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
-if [ ${failures[@]+"${failures[@]}"} ]; then
+if [[ ${failures[@]+"${failures[@]}"} ]]; then
 	echo ""
 	echo "${bold}${red}Build Failures:${normal}"
 	for fail in ${failures[@]}; do


### PR DESCRIPTION
Previous version had error that caused travis not to work. Essentially if the failures array had strings with special characters the script would fail before actually catching and reporting failed builds.

Note that travis won't pass on this (because it should fix travis and the all the adc apps are currently broken). 