### PR TITLE
add Signpost Tock Firmware Update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "apps/support/mbedtls/mbedtls"]
     path = apps/support/mbedtls/mbedtls
     url = https://github.com/lab11/mbedtls
+[submodule "kernel/boards/bootloader/tock-bootloader"]
+	path = kernel/boards/bootloader/tock-bootloader
+	url = https://github.com/lab11/tock-bootloader

--- a/apps/libsignpost/signpost_tock_firmware_update.c
+++ b/apps/libsignpost/signpost_tock_firmware_update.c
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 
+#include "tock.h"
 #include "signpost_tock_firmware_update.h"
 
 
@@ -13,7 +14,7 @@ int signpost_tock_firmware_update_go(uint32_t source,
   ret = allow(DRIVER_NUM_STFU, 0, (uint8_t*) config, 16);
   if (ret < 0) return ret;
 
-  command(DRIVER_NUM_STFU, 1, 0);
+  return command(DRIVER_NUM_STFU, 1, 0);
 }
 
 struct stfu_holding_data {
@@ -23,7 +24,7 @@ struct stfu_holding_data {
 static struct stfu_holding_data result = { .fired = false };
 
 // Internal callback for faking synchronous reads
-static void stfu_holding_cb(int value,
+static void stfu_holding_cb(__attribute__ ((unused)) int value,
                        __attribute__ ((unused)) int unused1,
                        __attribute__ ((unused)) int unused2,
                        void* ud) {

--- a/apps/libsignpost/signpost_tock_firmware_update.c
+++ b/apps/libsignpost/signpost_tock_firmware_update.c
@@ -1,0 +1,51 @@
+#include <stdbool.h>
+
+#include "signpost_tock_firmware_update.h"
+
+
+int signpost_tock_firmware_update_go(uint32_t source,
+                                     uint32_t destination,
+                                     uint32_t length,
+                                     uint32_t crc) {
+  int ret;
+  uint32_t config[4] = {source, destination, length, crc};
+
+  ret = allow(DRIVER_NUM_STFU, 0, (uint8_t*) config, 16);
+  if (ret < 0) return ret;
+
+  command(DRIVER_NUM_STFU, 1, 0);
+}
+
+struct stfu_holding_data {
+  bool fired;
+};
+
+static struct stfu_holding_data result = { .fired = false };
+
+// Internal callback for faking synchronous reads
+static void stfu_holding_cb(int value,
+                       __attribute__ ((unused)) int unused1,
+                       __attribute__ ((unused)) int unused2,
+                       void* ud) {
+  struct stfu_holding_data* data = (struct stfu_holding_data*) ud;
+  data->fired = true;
+}
+
+int signpost_tock_firmware_update_write_buffer(uint8_t* buffer, uint32_t offset, uint32_t length) {
+  int ret;
+
+  ret = subscribe(DRIVER_NUM_STFU_HOLDING, 1, stfu_holding_cb, (void*) &result);
+  if (ret < 0) return ret;
+
+  ret = allow(DRIVER_NUM_STFU_HOLDING, 1, (void*) buffer, length);
+  if (ret < 0) return ret;
+
+  uint32_t arg0 = (length << 8) | 3;
+  ret = command(DRIVER_NUM_STFU_HOLDING, (int) arg0, (int) offset);
+  if (ret < 0) return ret;
+
+  // Wait for the callback.
+  yield_for(&result.fired);
+
+  return 0;
+}

--- a/apps/libsignpost/signpost_tock_firmware_update.h
+++ b/apps/libsignpost/signpost_tock_firmware_update.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+
+#define DRIVER_NUM_STFU 120
+#define DRIVER_NUM_STFU_HOLDING 121
+
+int signpost_tock_firmware_update_go(uint32_t source,
+                                     uint32_t destination,
+                                     uint32_t length,
+                                     uint32_t crc);
+
+// Offset is in bytes, starting from 0. The app has a "virtual address space"
+// from where it assigned in the board main.rs.
+// Length is in bytes.
+int signpost_tock_firmware_update_write_buffer(uint8_t* buffer, uint32_t offset, uint32_t length);

--- a/apps/tests/stfu_test/Makefile
+++ b/apps/tests/stfu_test/Makefile
@@ -1,0 +1,17 @@
+# makefile for user application
+
+# don't care
+#TOCK_BOARD = audio_module
+
+STACK_SIZE = 4096
+APP_HEAP_SIZE = 4096
+
+# the current directory
+APP_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# files needed for this code
+C_SRCS   := main.c
+
+# include makefile settings that are shared between applications
+include ../../AppMakefile.mk
+

--- a/apps/tests/stfu_test/README.md
+++ b/apps/tests/stfu_test/README.md
@@ -1,0 +1,6 @@
+Signpost Tock Firmware Update Test App
+======================================
+
+This app expects you to use `tockloader flash` to put an app at address 0x60000
+(use the blink app). Then it changes the app's name before instructing the
+system to overwrite this app with the blink app.

--- a/apps/tests/stfu_test/main.c
+++ b/apps/tests/stfu_test/main.c
@@ -1,7 +1,8 @@
 #include <signpost_tock_firmware_update.h>
+#include "tock.h"
 
 
-int main () {
+int main (void) {
   int ret;
 
   printf("started\n");

--- a/apps/tests/stfu_test/main.c
+++ b/apps/tests/stfu_test/main.c
@@ -7,10 +7,10 @@ int main (void) {
 
   printf("started\n");
 
-  uint8_t buffer[4] = {74, 79, 83, 72};
-  ret = signpost_tock_firmware_update_write_buffer(buffer, 0x304, 4);
-  printf("rename %s\n", tock_strerror(ret));
+  //uint8_t buffer[4] = {74, 79, 83, 72};
+  //ret = signpost_tock_firmware_update_write_buffer(buffer, 0x304, 4);
+  //printf("rename %s\n", tock_strerror(ret));
 
-  ret = signpost_tock_firmware_update_go(0x60000, 0x30000, 1024, 0);
+  ret = signpost_tock_firmware_update_go(0x60000, 0x30000, 1024, 0xb13aeefa);
   printf("ok %s\n", tock_strerror(ret));
 }

--- a/apps/tests/stfu_test/main.c
+++ b/apps/tests/stfu_test/main.c
@@ -1,0 +1,15 @@
+#include <signpost_tock_firmware_update.h>
+
+
+int main () {
+  int ret;
+
+  printf("started\n");
+
+  uint8_t buffer[4] = {74, 79, 83, 72};
+  ret = signpost_tock_firmware_update_write_buffer(buffer, 0x304, 4);
+  printf("rename %s\n", tock_strerror(ret));
+
+  ret = signpost_tock_firmware_update_go(0x60000, 0x30000, 1024, 0);
+  printf("ok %s\n", tock_strerror(ret));
+}

--- a/kernel/boards/Signpost-SAM4L-kernel.mk
+++ b/kernel/boards/Signpost-SAM4L-kernel.mk
@@ -20,7 +20,11 @@ TOCKLOADER=tockloader
 # Where in the SAM4L flash to load the kernel with `tockloader`
 KERNEL_ADDRESS=0x10000
 
-BOOTLOADER_FILE = $(SIGNPOST_BOARDS_DIR)/bootloader/justjump_bootloader.bin
+BOOTLOADER_FILE = $(SIGNPOST_BOARDS_DIR)/bootloader/tock-bootloader/build/signpost_bootloader.bin
+BOOTLOADER_DIRECTORY = $(SIGNPOST_BOARDS_DIR)/bootloader/tock-bootloader
+
+$(BOOTLOADER_FILE):
+	make -C $(BOOTLOADER_DIRECTORY)
 
 # Upload programs over uart with tockloader
 ifdef PORT

--- a/kernel/boards/ambient_module/src/main.rs
+++ b/kernel/boards/ambient_module/src/main.rs
@@ -55,6 +55,9 @@ struct AmbientModule {
     isl29035: &'static capsules::isl29035::Isl29035<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     tsl2561: &'static capsules::tsl2561::TSL2561<'static>,
     app_watchdog: &'static signpost_drivers::app_watchdog::AppWatchdog<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+    stfu: &'static signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+    stfu_holding: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
     rng: &'static capsules::rng::SimpleRng<'static, sam4l::trng::Trng<'static>>,
     app_flash: &'static capsules::app_flash_driver::AppFlash<'static>,
     ipc: kernel::ipc::IPC,
@@ -82,6 +85,8 @@ impl Platform for AmbientModule {
             30 => f(Some(self.app_flash)),
 
             108 => f(Some(self.app_watchdog)),
+            120 => f(Some(self.stfu)),
+            121 => f(Some(self.stfu_holding)),
 
             0xff => f(Some(&self.ipc)),
             _ => f(None)
@@ -352,6 +357,58 @@ pub unsafe fn reset_handler() {
         signpost_drivers::watchdog_kernel::WatchdogKernel::new(watchdog_alarm, &sam4l::wdt::WDT, 1200));
     watchdog_alarm.set_client(watchdog);
 
+    //
+    // Flash
+    //
+
+    let mux_flash = static_init!(
+        capsules::virtual_flash::MuxFlash<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::MuxFlash::new(&sam4l::flashcalw::FLASH_CONTROLLER));
+    hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, mux_flash);
+
+    //
+    // Firmware Update
+    //
+    let virtual_flash_stfu_holding = static_init!(
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::FlashUser::new(mux_flash));
+    pub static mut STFU_HOLDING_PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
+    let stfu_holding_nv_to_page = static_init!(
+        capsules::nonvolatile_to_pages::NonvolatileToPages<'static,
+            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+        capsules::nonvolatile_to_pages::NonvolatileToPages::new(
+            virtual_flash_stfu_holding,
+            &mut STFU_HOLDING_PAGEBUFFER));
+    hil::flash::HasClient::set_client(virtual_flash_stfu_holding, stfu_holding_nv_to_page);
+
+    pub static mut STFU_HOLDING_BUFFER: [u8; 512] = [0; 512];
+    let stfu_holding = static_init!(
+        capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
+        capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
+            stfu_holding_nv_to_page, kernel::Container::create(),
+            0x60000, // Start address for userspace accessible region
+            0x20000, // Length of userspace accessible region
+            0,       // Start address of kernel accessible region
+            0,       // Length of kernel accessible region
+            &mut STFU_HOLDING_BUFFER));
+    hil::nonvolatile_storage::NonvolatileStorage::set_client(stfu_holding_nv_to_page, stfu_holding);
+
+
+    let virtual_flash_btldrflags = static_init!(
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::FlashUser::new(mux_flash));
+    pub static mut BTLDRPAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
+    let stfu = static_init!(
+        signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
+            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+        signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate::new(
+            virtual_flash_btldrflags,
+            &mut BTLDRPAGEBUFFER));
+    hil::flash::HasClient::set_client(virtual_flash_btldrflags, stfu);
+
+
 
     //
     // Actual platform object
@@ -369,6 +426,8 @@ pub unsafe fn reset_handler() {
         app_watchdog: app_watchdog,
         rng: rng,
         app_flash: app_flash,
+        stfu: stfu,
+        stfu_holding: stfu_holding,
         ipc: kernel::ipc::IPC::new(),
     };
 

--- a/kernel/boards/audio_module/src/main.rs
+++ b/kernel/boards/audio_module/src/main.rs
@@ -53,6 +53,9 @@ struct AudioModule {
     app_watchdog: &'static signpost_drivers::app_watchdog::AppWatchdog<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     rng: &'static capsules::rng::SimpleRng<'static, sam4l::trng::Trng<'static>>,
     app_flash: &'static capsules::app_flash_driver::AppFlash<'static>,
+    stfu: &'static signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+    stfu_holding: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
     ipc: kernel::ipc::IPC,
 }
 
@@ -72,6 +75,9 @@ impl Platform for AudioModule {
             30 => f(Some(self.app_flash)),
 
             108 => f(Some(self.app_watchdog)),
+
+            120 => f(Some(self.stfu)),
+            121 => f(Some(self.stfu_holding)),
 
             0xff => f(Some(&self.ipc)),
             _ => f(None)
@@ -317,6 +323,58 @@ pub unsafe fn reset_handler() {
     sam4l::gpio::PB[14].set();   // green LED on
 
     //
+    // Flash
+    //
+
+    let mux_flash = static_init!(
+        capsules::virtual_flash::MuxFlash<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::MuxFlash::new(&sam4l::flashcalw::FLASH_CONTROLLER));
+    hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, mux_flash);
+
+    //
+    // Firmware Update
+    //
+    let virtual_flash_stfu_holding = static_init!(
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::FlashUser::new(mux_flash));
+    pub static mut STFU_HOLDING_PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
+    let stfu_holding_nv_to_page = static_init!(
+        capsules::nonvolatile_to_pages::NonvolatileToPages<'static,
+            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+        capsules::nonvolatile_to_pages::NonvolatileToPages::new(
+            virtual_flash_stfu_holding,
+            &mut STFU_HOLDING_PAGEBUFFER));
+    hil::flash::HasClient::set_client(virtual_flash_stfu_holding, stfu_holding_nv_to_page);
+
+    pub static mut STFU_HOLDING_BUFFER: [u8; 512] = [0; 512];
+    let stfu_holding = static_init!(
+        capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
+        capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
+            stfu_holding_nv_to_page, kernel::Container::create(),
+            0x60000, // Start address for userspace accessible region
+            0x20000, // Length of userspace accessible region
+            0,       // Start address of kernel accessible region
+            0,       // Length of kernel accessible region
+            &mut STFU_HOLDING_BUFFER));
+    hil::nonvolatile_storage::NonvolatileStorage::set_client(stfu_holding_nv_to_page, stfu_holding);
+
+
+    let virtual_flash_btldrflags = static_init!(
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::FlashUser::new(mux_flash));
+    pub static mut BTLDRPAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
+    let stfu = static_init!(
+        signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
+            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+        signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate::new(
+            virtual_flash_btldrflags,
+            &mut BTLDRPAGEBUFFER));
+    hil::flash::HasClient::set_client(virtual_flash_btldrflags, stfu);
+
+
+    //
     //
     // Actual platform object
     //
@@ -330,6 +388,8 @@ pub unsafe fn reset_handler() {
         app_watchdog: app_watchdog,
         rng: rng,
         app_flash: app_flash,
+        stfu: stfu,
+        stfu_holding: stfu_holding,
         ipc: kernel::ipc::IPC::new(),
     };
 

--- a/kernel/boards/controller/src/main.rs
+++ b/kernel/boards/controller/src/main.rs
@@ -585,6 +585,7 @@ pub unsafe fn reset_handler() {
         capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
         capsules::virtual_flash::FlashUser::new(mux_flash));
     pub static mut STFU_HOLDING_PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
     let stfu_holding_nv_to_page = static_init!(
         capsules::nonvolatile_to_pages::NonvolatileToPages<'static,
             capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
@@ -592,6 +593,7 @@ pub unsafe fn reset_handler() {
             virtual_flash_stfu_holding,
             &mut STFU_HOLDING_PAGEBUFFER));
     hil::flash::HasClient::set_client(virtual_flash_stfu_holding, stfu_holding_nv_to_page);
+
     pub static mut STFU_HOLDING_BUFFER: [u8; 512] = [0; 512];
     let stfu_holding = static_init!(
         capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
@@ -608,13 +610,14 @@ pub unsafe fn reset_handler() {
     let virtual_flash_btldrflags = static_init!(
         capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
         capsules::virtual_flash::FlashUser::new(mux_flash));
-    pub static mut PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+    pub static mut BTLDRPAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
     let stfu = static_init!(
         signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
             capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
         signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate::new(
             virtual_flash_btldrflags,
-            &mut PAGEBUFFER));
+            &mut BTLDRPAGEBUFFER));
     hil::flash::HasClient::set_client(virtual_flash_btldrflags, stfu);
 
 

--- a/kernel/boards/microwave_radar_module/src/main.rs
+++ b/kernel/boards/microwave_radar_module/src/main.rs
@@ -53,6 +53,9 @@ struct MicrowaveRadarModule {
     app_watchdog: &'static signpost_drivers::app_watchdog::AppWatchdog<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     rng: &'static capsules::rng::SimpleRng<'static, sam4l::trng::Trng<'static>>,
     app_flash: &'static capsules::app_flash_driver::AppFlash<'static>,
+    stfu: &'static signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+    stfu_holding: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
     ipc: kernel::ipc::IPC,
 }
 
@@ -72,6 +75,8 @@ impl Platform for MicrowaveRadarModule {
             30 => f(Some(self.app_flash)),
 
             108 => f(Some(self.app_watchdog)),
+            120 => f(Some(self.stfu)),
+            121 => f(Some(self.stfu_holding)),
 
             0xff => f(Some(&self.ipc)),
             _ => f(None)
@@ -275,6 +280,58 @@ pub unsafe fn reset_handler() {
         signpost_drivers::watchdog_kernel::WatchdogKernel::new(watchdog_alarm, &sam4l::wdt::WDT, 1200));
     watchdog_alarm.set_client(watchdog);
 
+    //
+    // Flash
+    //
+
+    let mux_flash = static_init!(
+        capsules::virtual_flash::MuxFlash<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::MuxFlash::new(&sam4l::flashcalw::FLASH_CONTROLLER));
+    hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, mux_flash);
+
+    //
+    // Firmware Update
+    //
+    let virtual_flash_stfu_holding = static_init!(
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::FlashUser::new(mux_flash));
+    pub static mut STFU_HOLDING_PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
+    let stfu_holding_nv_to_page = static_init!(
+        capsules::nonvolatile_to_pages::NonvolatileToPages<'static,
+            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+        capsules::nonvolatile_to_pages::NonvolatileToPages::new(
+            virtual_flash_stfu_holding,
+            &mut STFU_HOLDING_PAGEBUFFER));
+    hil::flash::HasClient::set_client(virtual_flash_stfu_holding, stfu_holding_nv_to_page);
+
+    pub static mut STFU_HOLDING_BUFFER: [u8; 512] = [0; 512];
+    let stfu_holding = static_init!(
+        capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
+        capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
+            stfu_holding_nv_to_page, kernel::Container::create(),
+            0x60000, // Start address for userspace accessible region
+            0x20000, // Length of userspace accessible region
+            0,       // Start address of kernel accessible region
+            0,       // Length of kernel accessible region
+            &mut STFU_HOLDING_BUFFER));
+    hil::nonvolatile_storage::NonvolatileStorage::set_client(stfu_holding_nv_to_page, stfu_holding);
+
+
+    let virtual_flash_btldrflags = static_init!(
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::FlashUser::new(mux_flash));
+    pub static mut BTLDRPAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
+    let stfu = static_init!(
+        signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
+            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+        signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate::new(
+            virtual_flash_btldrflags,
+            &mut BTLDRPAGEBUFFER));
+    hil::flash::HasClient::set_client(virtual_flash_btldrflags, stfu);
+
+
 
     //
     // Actual platform object
@@ -289,6 +346,8 @@ pub unsafe fn reset_handler() {
         app_watchdog: app_watchdog,
         rng: rng,
         app_flash: app_flash,
+        stfu: stfu,
+        stfu_holding: stfu_holding,
         ipc: kernel::ipc::IPC::new(),
     };
 

--- a/kernel/boards/radio_module/src/main.rs
+++ b/kernel/boards/radio_module/src/main.rs
@@ -58,6 +58,9 @@ struct RadioModule {
     app_watchdog: &'static signpost_drivers::app_watchdog::AppWatchdog<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     rng: &'static capsules::rng::SimpleRng<'static, sam4l::trng::Trng<'static>>,
     app_flash: &'static capsules::app_flash_driver::AppFlash<'static>,
+    stfu: &'static signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+    stfu_holding: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
     ipc: kernel::ipc::IPC,
 }
 
@@ -79,6 +82,8 @@ impl Platform for RadioModule {
             108 => f(Some(self.app_watchdog)),
             109 => f(Some(self.lora_console)),
             110 => f(Some(self.three_g_console)),
+            120 => f(Some(self.stfu)),
+            121 => f(Some(self.stfu_holding)),
 
             0xff => f(Some(&self.ipc)),
             _ => f(None)
@@ -334,6 +339,58 @@ pub unsafe fn reset_handler() {
     watchdog_alarm.set_client(watchdog);
 
     //
+    // Flash
+    //
+
+    let mux_flash = static_init!(
+        capsules::virtual_flash::MuxFlash<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::MuxFlash::new(&sam4l::flashcalw::FLASH_CONTROLLER));
+    hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, mux_flash);
+
+    //
+    // Firmware Update
+    //
+    let virtual_flash_stfu_holding = static_init!(
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::FlashUser::new(mux_flash));
+    pub static mut STFU_HOLDING_PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
+    let stfu_holding_nv_to_page = static_init!(
+        capsules::nonvolatile_to_pages::NonvolatileToPages<'static,
+            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+        capsules::nonvolatile_to_pages::NonvolatileToPages::new(
+            virtual_flash_stfu_holding,
+            &mut STFU_HOLDING_PAGEBUFFER));
+    hil::flash::HasClient::set_client(virtual_flash_stfu_holding, stfu_holding_nv_to_page);
+
+    pub static mut STFU_HOLDING_BUFFER: [u8; 512] = [0; 512];
+    let stfu_holding = static_init!(
+        capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
+        capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
+            stfu_holding_nv_to_page, kernel::Container::create(),
+            0x60000, // Start address for userspace accessible region
+            0x20000, // Length of userspace accessible region
+            0,       // Start address of kernel accessible region
+            0,       // Length of kernel accessible region
+            &mut STFU_HOLDING_BUFFER));
+    hil::nonvolatile_storage::NonvolatileStorage::set_client(stfu_holding_nv_to_page, stfu_holding);
+
+
+    let virtual_flash_btldrflags = static_init!(
+        capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>,
+        capsules::virtual_flash::FlashUser::new(mux_flash));
+    pub static mut BTLDRPAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+
+    let stfu = static_init!(
+        signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate<'static,
+            capsules::virtual_flash::FlashUser<'static, sam4l::flashcalw::FLASHCALW>>,
+        signpost_drivers::signpost_tock_firmware_update::SignpostTockFirmwareUpdate::new(
+            virtual_flash_btldrflags,
+            &mut BTLDRPAGEBUFFER));
+    hil::flash::HasClient::set_client(virtual_flash_btldrflags, stfu);
+
+
+    //
     // Actual platform object
     //
     let radio_module = RadioModule {
@@ -348,6 +405,8 @@ pub unsafe fn reset_handler() {
         app_watchdog: app_watchdog,
         rng: rng,
         app_flash: app_flash,
+        stfu: stfu,
+        stfu_holding: stfu_holding,
         ipc: kernel::ipc::IPC::new(),
     };
 

--- a/kernel/signpost_drivers/src/lib.rs
+++ b/kernel/signpost_drivers/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(const_fn)]
 #![no_std]
 
+#[macro_use(debug)]
 extern crate kernel;
 extern crate signpost_hil;
 
@@ -17,3 +18,5 @@ pub mod watchdog_kernel;
 pub mod gps_console;
 pub mod sara_u260;
 pub mod xdot;
+
+pub mod signpost_tock_firmware_update;

--- a/kernel/signpost_drivers/src/signpost_tock_firmware_update.rs
+++ b/kernel/signpost_drivers/src/signpost_tock_firmware_update.rs
@@ -1,0 +1,142 @@
+//! Tell the bootloader to load new code.
+
+use core::cell::Cell;
+use core::cmp;
+use kernel::common::take_cell::TakeCell;
+use kernel::common::take_cell::MapCell;
+use kernel::hil;
+use kernel::{AppId, AppSlice, Callback, Container, Driver, ReturnCode, Shared};
+
+/// This module is either waiting to do something, or handling a read/write.
+#[derive(Clone,Copy,Debug,PartialEq)]
+enum State {
+    Idle,
+    Read,
+    Write,
+}
+
+pub struct SignpostTockFirmwareUpdate<'a, F: hil::flash::Flash + 'static> {
+    /// The module providing a `Flash` interface.
+    driver: &'a F,
+    config: MapCell<AppSlice<Shared, u8>>,
+    pagebuffer: TakeCell<'static, F::Page>,
+    source: Cell<u32>,
+    destination: Cell<u32>,
+    length: Cell<u32>,
+    crc: Cell<u32>,
+}
+
+impl<'a, F: hil::flash::Flash + 'a> SignpostTockFirmwareUpdate<'a, F> {
+    pub fn new(driver: &'a F, buffer: &'static mut F::Page) -> SignpostTockFirmwareUpdate<'a, F> {
+        SignpostTockFirmwareUpdate {
+            driver: driver,
+            config: MapCell::empty(),
+            pagebuffer: TakeCell::new(buffer),
+            source: Cell::new(0),
+            destination: Cell::new(0),
+            length: Cell::new(0),
+            crc: Cell::new(0),
+        }
+    }
+
+    fn do_firmware_update (&self, source: u32, destination: u32, length: u32, crc: u32) -> ReturnCode {
+        self.pagebuffer.take().map_or(ReturnCode::ERESERVE, move |pagebuffer| {
+            let page_size = pagebuffer.as_mut().len();
+
+            self.source.set(source);
+            self.destination.set(destination);
+            self.length.set(length);
+            self.crc.set(crc);
+
+            debug!("a");
+
+            // Second page has the bootloader flags on it.
+            self.driver.read_page(2, pagebuffer)
+        })
+    }
+}
+
+
+
+impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for SignpostTockFirmwareUpdate<'a, F> {
+    fn read_complete(&self, pagebuffer: &'static mut F::Page, _error: hil::flash::Error) {
+        // Put the correct values in the correct spots.
+
+        pagebuffer.as_mut()[492] = 1; // enable
+        pagebuffer.as_mut()[493] = 0;
+        pagebuffer.as_mut()[494] = 0;
+        pagebuffer.as_mut()[495] = 0;
+        pagebuffer.as_mut()[496] = ((self.source.get() >>  0) & 0xFF) as u8;
+        pagebuffer.as_mut()[497] = ((self.source.get() >>  8) & 0xFF) as u8;
+        pagebuffer.as_mut()[498] = ((self.source.get() >> 16) & 0xFF) as u8;
+        pagebuffer.as_mut()[499] = ((self.source.get() >> 24) & 0xFF) as u8;
+        pagebuffer.as_mut()[500] = ((self.destination.get() >>  0) & 0xFF) as u8;
+        pagebuffer.as_mut()[501] = ((self.destination.get() >>  8) & 0xFF) as u8;
+        pagebuffer.as_mut()[502] = ((self.destination.get() >> 16) & 0xFF) as u8;
+        pagebuffer.as_mut()[503] = ((self.destination.get() >> 24) & 0xFF) as u8;
+        pagebuffer.as_mut()[504] = ((self.length.get() >>  0) & 0xFF) as u8;
+        pagebuffer.as_mut()[505] = ((self.length.get() >>  8) & 0xFF) as u8;
+        pagebuffer.as_mut()[506] = ((self.length.get() >> 16) & 0xFF) as u8;
+        pagebuffer.as_mut()[507] = ((self.length.get() >> 24) & 0xFF) as u8;
+        pagebuffer.as_mut()[508] = ((self.crc.get() >>  0) & 0xFF) as u8;
+        pagebuffer.as_mut()[509] = ((self.crc.get() >>  8) & 0xFF) as u8;
+        pagebuffer.as_mut()[510] = ((self.crc.get() >> 16) & 0xFF) as u8;
+        pagebuffer.as_mut()[511] = ((self.crc.get() >> 24) & 0xFF) as u8;
+
+        self.driver.write_page(2, pagebuffer);
+    }
+
+    fn write_complete(&self, pagebuffer: &'static mut F::Page, _error: hil::flash::Error) {
+        // Reboot!
+    }
+
+    fn erase_complete(&self, _error: hil::flash::Error) {}
+}
+
+/// Provide an interface for userland.
+impl<'a, F: hil::flash::Flash + 'a> Driver for SignpostTockFirmwareUpdate<'a, F> {
+    /// Setup buffer for passing settings in.
+    ///
+    /// ### `allow_num`
+    ///
+    /// - `0`: Buffer that is 16 bytes long and will contain reset config information.
+    fn allow(&self, appid: AppId, allow_num: usize, slice: AppSlice<Shared, u8>) -> ReturnCode {
+        if slice.len() == 16 {
+            self.config.replace(slice);
+            ReturnCode::SUCCESS
+        } else {
+            ReturnCode::EINVAL
+        }
+    }
+
+    /// Command interface.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Return SUCCESS if this driver is included on the platform.
+    /// - `1`: Do it.
+    fn command(&self, command_num: usize, _arg1: usize, _appid: AppId) -> ReturnCode {
+
+        match command_num {
+            0 => /* This driver exists. */ ReturnCode::SUCCESS,
+
+            // Do it.
+            1 => {
+                self.config.map_or(ReturnCode::ERESERVE, |buffer| {
+                    let mut count = 0;
+                    let mut params: [u32; 4] = [0, 0, 0, 0];
+                    for chunk in buffer.chunks_mut(4) {
+                        params[count] = (chunk[0] as u32) << 0 |
+                                        (chunk[1] as u32) << 8 |
+                                        (chunk[2] as u32) << 16 |
+                                        (chunk[3] as u32) << 24;
+                        count += 1;
+                    }
+                    self.do_firmware_update(params[0], params[1], params[2], params[3])
+                })
+            }
+
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}


### PR DESCRIPTION
Need the lab11/tock-bootloader bootloader for this.

There is a quick test app that I used to test this. It is still missing the userspace code that can actually put an app in the holding space in flash.

Also the capsule in signpost_drivers is quick and dirty, FYI.

Question: how to actually reset the SAM4L?