### PR TITLE
use snprintf instead

### DIFF
--- a/apps/libsignpost/gps.c
+++ b/apps/libsignpost/gps.c
@@ -94,7 +94,7 @@ static int gps_send_msg (const char* msg) {
     message_sent = false;
     snprintf(msg_buffer, 60, "%s%02X\r\n", msg, minmea_checksum(msg));
 
-    int ret = allow(DRIVER_NUM_GPS, 1, (void*)msg_buffer, strlen(msg_buffer));
+    int ret = allow(DRIVER_NUM_GPS, 1, (void*)msg_buffer, strnlen(msg_buffer,60));
     if(ret < 0) return ret;
     ret = subscribe(DRIVER_NUM_GPS, 1, gps_tx_callback, NULL);
     if(ret < 0) return ret;

--- a/apps/libsignpost/gps.c
+++ b/apps/libsignpost/gps.c
@@ -87,11 +87,12 @@ static void gps_tx_callback (
 }
 
 static int gps_send_msg (const char* msg) {
-    static char msg_buffer[50] = {0};
+
+    static char msg_buffer[60] = {0};
 
     // create message buffer
     message_sent = false;
-    sprintf(msg_buffer, "%s%02X\r\n", msg, minmea_checksum(msg));
+    snprintf(msg_buffer, 60, "%s%02X\r\n", msg, minmea_checksum(msg));
 
     int ret = allow(DRIVER_NUM_GPS, 1, (void*)msg_buffer, strlen(msg_buffer));
     if(ret < 0) return ret;
@@ -99,7 +100,7 @@ static int gps_send_msg (const char* msg) {
     if(ret < 0) return ret;
 
     yield_for(&message_sent);
-    
+
     return TOCK_SUCCESS;
 }
 

--- a/apps/libsignpost/signpost_api.c
+++ b/apps/libsignpost/signpost_api.c
@@ -1097,7 +1097,7 @@ int signpost_json_send(uint8_t destination_address, size_t field_count, ... ) {
         // value:
         // TODO assumes integer value right now
         snprintf(json_blob+size, MAX_JSON_BLOB_SIZE-size, "%d", field.value);
-        size+=strlen(json_blob+size);
+        size+=strnlen(json_blob+size,MAX_JSON_BLOB_SIZE-size);
     }
     json_blob[size++] = '}';
     json_blob[size++] = '\0';

--- a/apps/libsignpost/signpost_api.c
+++ b/apps/libsignpost/signpost_api.c
@@ -711,7 +711,7 @@ int signpost_networking_post(const char* url, http_request request, http_respons
         memcpy(send+send_index,(uint8_t*)"content-length",clen);
         send_index += clen;
         char cbuf[5];
-        sprintf(cbuf,"%d",len);
+        snprintf(cbuf,5,"%d",len);
         clen = strlen(cbuf);
         send[send_index] = clen;
         send_index++;
@@ -1096,7 +1096,7 @@ int signpost_json_send(uint8_t destination_address, size_t field_count, ... ) {
         json_blob[size++] = ':';
         // value:
         // TODO assumes integer value right now
-        sprintf(json_blob+size, "%d", field.value);
+        snprintf(json_blob+size, MAX_JSON_BLOB_SIZE-size, "%d", field.value);
         size+=strlen(json_blob+size);
     }
     json_blob[size++] = '}';

--- a/apps/libsignpost/signpost_api.c
+++ b/apps/libsignpost/signpost_api.c
@@ -712,7 +712,7 @@ int signpost_networking_post(const char* url, http_request request, http_respons
         send_index += clen;
         char cbuf[5];
         snprintf(cbuf,5,"%d",len);
-        clen = strlen(cbuf);
+        clen = strnlen(cbuf,5);
         send[send_index] = clen;
         send_index++;
         memcpy(send+send_index,cbuf,clen);


### PR DESCRIPTION
removes the three sprintfs from libsignpost. Also increased gps message buffer size (which clearly need to be larger). 