### PR TITLE
tock rng functions control hardware

### DIFF
--- a/apps/libsignpost/port_signpost_tock.c
+++ b/apps/libsignpost/port_signpost_tock.c
@@ -7,6 +7,7 @@
 #include "i2c_master_slave.h"
 #include "led.h"
 #include "port_signpost.h"
+#include "rng.h"
 #include "signpost_entropy.h"
 #include "timer.h"
 #include "tock.h"
@@ -193,18 +194,13 @@ int port_signpost_debug_led_off(void){
 }
 
 int port_rng_init(void) {
-    if (signpost_entropy_init() < 0) return SB_PORT_FAIL;
     return SB_PORT_SUCCESS;
 }
 
 int port_rng_sync(uint8_t* buf, uint32_t len, uint32_t num) {
-    int rc;
-    size_t bytes_to_request;
-    if (len < num) bytes_to_request = len;
-    else bytes_to_request = num;
-    rc = signpost_entropy_rand(buf, bytes_to_request);
-    if (rc < 0) return SB_PORT_FAIL;
-    return rc;
+    int rc = rng_sync(buf, len, num);
+    if (rc >= 0) return rc;
+    else return SB_PORT_FAIL;
 }
 
 int port_printf(const char *fmt, ...) {

--- a/apps/libsignpost/signbus_protocol_layer.c
+++ b/apps/libsignpost/signbus_protocol_layer.c
@@ -6,6 +6,7 @@
 #include "mbedtls/cipher.h"
 
 #include "port_signpost.h"
+#include "signpost_entropy.h"
 #include "signbus_app_layer.h"
 #include "signbus_io_interface.h"
 #include "signbus_protocol_layer.h"
@@ -41,7 +42,7 @@ static int cipher(
 
     if (operation == MBEDTLS_ENCRYPT) {
         // Get 16 random bits for IV
-        ret = port_rng_sync(ivenc, MBEDTLS_MAX_IV_LENGTH, MBEDTLS_MAX_IV_LENGTH);
+        ret = signpost_entropy_rand(ivenc, MBEDTLS_MAX_IV_LENGTH, MBEDTLS_MAX_IV_LENGTH);
         if (ret < 0) return SB_PORT_FAIL;
         // copy to iv, to send with encrypted content
         memcpy(iv, ivenc, MBEDTLS_MAX_IV_LENGTH);

--- a/apps/libsignpost/signpost_api.c
+++ b/apps/libsignpost/signpost_api.c
@@ -6,6 +6,7 @@
 #include "signbus_io_interface.h"
 #include "signpost_api.h"
 #include "port_signpost.h"
+#include "signpost_entropy.h"
 
 #include "mbedtls/ecdh.h"
 #include "mbedtls/ecp.h"
@@ -374,7 +375,7 @@ static int signpost_initialization_common(uint8_t i2c_address, api_handler_t** a
 
     // Initialize the lower layers
     signbus_io_init(i2c_address);
-    rc = port_rng_init();
+    rc = signpost_entropy_init();
     if (rc < 0) return rc;
     // See comment in protocol_layer.h
     signbus_protocol_setup_async(incoming_protocol_buffer, INCOMING_MESSAGE_BUFFER_LENGTH);

--- a/apps/libsignpost/signpost_entropy.c
+++ b/apps/libsignpost/signpost_entropy.c
@@ -17,23 +17,29 @@ static int rng_wrapper(void* data __attribute__ ((unused)), uint8_t* out, size_t
 }
 
 int signpost_entropy_init (void) {
-    int ret;
+    int rc;
+    // init rng
+    rc = port_rng_init();
+    if (rc < 0) return rc;
     // random start seed
-    ret = port_rng_sync(drbg_data, 32, 32);
-    if (ret < 0) return ret;
+    rc = port_rng_sync(drbg_data, 32, 32);
+    if (rc < 0) return rc;
 
     // init entropy and prng
     mbedtls_entropy_init(&entropy_context);
-    ret = mbedtls_entropy_add_source(&entropy_context, rng_wrapper, NULL, 48, true);
-    if (ret < 0) return ret;
+    rc = mbedtls_entropy_add_source(&entropy_context, rng_wrapper, NULL, 48, true);
+    if (rc < 0) return rc;
     mbedtls_ctr_drbg_free(&ctr_drbg_context);
     mbedtls_ctr_drbg_init(&ctr_drbg_context);
-    ret = mbedtls_ctr_drbg_seed(&ctr_drbg_context, mbedtls_entropy_func, &entropy_context, drbg_data, 32);
-    if (ret < 0) return ret;
+    rc = mbedtls_ctr_drbg_seed(&ctr_drbg_context, mbedtls_entropy_func, &entropy_context, drbg_data, 32);
+    if (rc < 0) return rc;
     mbedtls_ctr_drbg_set_prediction_resistance(&ctr_drbg_context, MBEDTLS_CTR_DRBG_PR_ON);
     return 0;
 }
 
-int signpost_entropy_rand(uint8_t* buf, size_t len) {
-    return mbedtls_ctr_drbg_random(&ctr_drbg_context, buf, len);
+int signpost_entropy_rand(uint8_t* buf, size_t len, size_t num) {
+    size_t bytes_to_request;
+    if (len < num) bytes_to_request = len;
+    else bytes_to_request = num;
+    return mbedtls_ctr_drbg_random(&ctr_drbg_context, buf, bytes_to_request);
 }

--- a/apps/libsignpost/signpost_entropy.h
+++ b/apps/libsignpost/signpost_entropy.h
@@ -5,7 +5,7 @@ extern "C" {
 #endif
 
 int signpost_entropy_init (void);
-int signpost_entropy_rand(uint8_t* buf, size_t len);
+int signpost_entropy_rand(uint8_t* buf, size_t len, size_t num);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Use signpost_entropy for random calls, use the port layer only to access hardware.